### PR TITLE
Fix default values for isFloat configuration

### DIFF
--- a/src/DataDefinitionsBundle/Interpreter/CoreShop/MoneyInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/CoreShop/MoneyInterpreter.php
@@ -45,7 +45,7 @@ final class MoneyInterpreter implements InterpreterInterface
 
     private function getValue(string $value, InterpreterContextInterface $context): int
     {
-        $inputIsFloat = $context->getConfiguration()['isFloat'];
+        $inputIsFloat = $context->getConfiguration()['isFloat'] ?? false;
 
         $value = preg_replace('/[^0-9,.]+/', '', $value);
 

--- a/src/DataDefinitionsBundle/Interpreter/CoreShop/PriceInterpreter.php
+++ b/src/DataDefinitionsBundle/Interpreter/CoreShop/PriceInterpreter.php
@@ -22,7 +22,7 @@ final class PriceInterpreter implements InterpreterInterface
 {
     public function interpret(InterpreterContextInterface $context): mixed
     {
-        $inputIsFloat = $context->getConfiguration()['isFloat'];
+        $inputIsFloat = $context->getConfiguration()['isFloat'] ?? false;
         $value = $context->getValue();
 
         if (\is_string($value)) {


### PR DESCRIPTION
## Summary
- avoid undefined index errors when reading `isFloat` in MoneyInterpreter and PriceInterpreter

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f63fc1fd883288f31372a2df05373