### PR TITLE
Add Flysystem export support

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -31,3 +31,15 @@ Export Definitions can only run (at the moment) using the Pimcore CLI. To run yo
 bin/console data-definitions:export -d 1 -p "{\"file\":\"test.json\"}"
 bin/console data-definitions:export -d name-of-definition -p "{\"file\":\"test.json\"}"
 ```
+
+### Export directly to a Flysystem storage
+
+You can export files directly to any configured Flysystem storage by passing the
+`storage` option together with the target `file` path:
+
+```cli
+bin/console data-definitions:export -d name -p '{"storage":"s3","file":"exports/result.csv"}'
+```
+
+The generated file will be uploaded to the specified storage instead of being
+written to the local filesystem.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="DataDefinitions">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/DataDefinitionsBundle/Provider/AbstractFileProvider.php
+++ b/src/DataDefinitionsBundle/Provider/AbstractFileProvider.php
@@ -89,4 +89,15 @@ abstract class AbstractFileProvider
 
         return $tmpFilePath;
     }
+
+    protected function putFile(string $path, array $params): void
+    {
+        if (isset($params['storage'], $params['file'])) {
+            $storage = $this->storageLocator->getStorage($params['storage']);
+
+            $stream = fopen($path, 'rb');
+            $storage->writeStream($params['file'], $stream);
+            fclose($stream);
+        }
+    }
 }

--- a/src/DataDefinitionsBundle/Provider/CsvProvider.php
+++ b/src/DataDefinitionsBundle/Provider/CsvProvider.php
@@ -21,6 +21,7 @@ use Instride\Bundle\DataDefinitionsBundle\Filter\FilterInterface;
 use Instride\Bundle\DataDefinitionsBundle\Model\ExportDefinitionInterface;
 use Instride\Bundle\DataDefinitionsBundle\Model\ImportDefinitionInterface;
 use Instride\Bundle\DataDefinitionsBundle\Model\ImportMapping\FromColumn;
+use Pimcore\File;
 use League\Csv\Reader;
 use League\Csv\Statement;
 use League\Csv\Writer;
@@ -128,7 +129,11 @@ class CsvProvider extends AbstractFileProvider implements ImportProviderInterfac
             return;
         }
 
-        $file = $this->getFile($params);
+        if (isset($params['storage'])) {
+            $file = File::getLocalTempFilePath(pathinfo($params['file'], PATHINFO_EXTENSION), true);
+        } else {
+            $file = $this->getFile($params);
+        }
 
         $headers = count($this->exportData) > 0 ? array_keys($this->exportData[0]) : [];
 
@@ -140,6 +145,12 @@ class CsvProvider extends AbstractFileProvider implements ImportProviderInterfac
         }
         $writer->insertOne($headers);
         $writer->insertAll($this->exportData);
+
+        $this->putFile($file, $params);
+
+        if (isset($params['storage'])) {
+            unlink($file);
+        }
     }
 
     public function addExportData(

--- a/src/DataDefinitionsBundle/Provider/ExcelProvider.php
+++ b/src/DataDefinitionsBundle/Provider/ExcelProvider.php
@@ -26,6 +26,7 @@ use OpenSpout\Writer\WriterInterface;
 use OpenSpout\Writer\XLSX\Writer;
 use Pimcore\Model\Asset;
 use Pimcore\Tool\Storage;
+use Pimcore\File;
 
 class ExcelProvider extends AbstractFileProvider implements ImportProviderInterface, ExportProviderInterface
 {
@@ -132,9 +133,20 @@ class ExcelProvider extends AbstractFileProvider implements ImportProviderInterf
             return;
         }
 
-        $file = $this->getFile($params);
+        if (isset($params['storage'])) {
+            $file = File::getLocalTempFilePath(pathinfo($params['file'], PATHINFO_EXTENSION), true);
+        } else {
+            $file = $this->getFile($params);
+        }
+
         copy($this->getExportPath(), $file);
         unlink($this->getExportPath());
+
+        $this->putFile($file, $params);
+
+        if (isset($params['storage'])) {
+            unlink($file);
+        }
     }
 
     private function createReader($path): ReaderInterface

--- a/src/DataDefinitionsBundle/Provider/JsonProvider.php
+++ b/src/DataDefinitionsBundle/Provider/JsonProvider.php
@@ -20,6 +20,7 @@ use Instride\Bundle\DataDefinitionsBundle\Filter\FilterInterface;
 use Instride\Bundle\DataDefinitionsBundle\Model\ExportDefinitionInterface;
 use Instride\Bundle\DataDefinitionsBundle\Model\ImportDefinitionInterface;
 use Instride\Bundle\DataDefinitionsBundle\Model\ImportMapping\FromColumn;
+use Pimcore\File;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 
@@ -98,9 +99,19 @@ class JsonProvider extends AbstractFileProvider implements ImportProviderInterfa
             return;
         }
 
-        $file = $this->getFile($params);
+        if (isset($params['storage'])) {
+            $file = File::getLocalTempFilePath(pathinfo($params['file'], PATHINFO_EXTENSION), true);
+        } else {
+            $file = $this->getFile($params);
+        }
 
         file_put_contents($file, json_encode($this->exportData));
+
+        $this->putFile($file, $params);
+
+        if (isset($params['storage'])) {
+            unlink($file);
+        }
     }
 
     public function addExportData(

--- a/src/DataDefinitionsBundle/Provider/XmlProvider.php
+++ b/src/DataDefinitionsBundle/Provider/XmlProvider.php
@@ -163,9 +163,20 @@ class XmlProvider extends AbstractFileProvider implements ImportProviderInterfac
             return;
         }
 
-        $file = $this->getFile($params);
+        if (isset($params['storage'])) {
+            $file = File::getLocalTempFilePath(pathinfo($params['file'], PATHINFO_EXTENSION), true);
+        } else {
+            $file = $this->getFile($params);
+        }
+
         copy($this->getExportPath(), $file);
         unlink($this->getExportPath());
+
+        $this->putFile($file, $params);
+
+        if (isset($params['storage'])) {
+            unlink($file);
+        }
     }
 
     private function getXMLWriter(): XMLWriter

--- a/tests/ExportStorageTest.php
+++ b/tests/ExportStorageTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+if (!defined('PIMCORE_SYSTEM_TEMP_DIRECTORY')) {
+    define('PIMCORE_SYSTEM_TEMP_DIRECTORY', sys_get_temp_dir());
+}
+
+use Doctrine\Persistence\ConnectionRegistry;
+use Instride\Bundle\DataDefinitionsBundle\Provider\JsonProvider;
+use Instride\Bundle\DataDefinitionsBundle\Service\StorageLocator;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use PHPUnit\Framework\TestCase;
+use Pimcore\Helper\LongRunningHelper;
+use Psr\Container\ContainerInterface;
+use Instride\Bundle\DataDefinitionsBundle\Model\ExportDefinitionInterface;
+
+class ExportStorageTest extends TestCase
+{
+    public function testExportToFlysystemStorage(): void
+    {
+        $dir = sys_get_temp_dir().'/dd_test_'.uniqid();
+        mkdir($dir);
+        $adapter = new LocalFilesystemAdapter($dir);
+        $fs = new Filesystem($adapter);
+
+        $container = new class($fs) implements ContainerInterface {
+            public function __construct(private FilesystemOperator $fs) {}
+            public function get(string $id)
+            {
+                return $this->fs;
+            }
+            public function has(string $id): bool
+            {
+                return true;
+            }
+        };
+
+        $locator = new StorageLocator($container);
+
+        $registry = new class implements ConnectionRegistry {
+            public function getDefaultConnectionName(){}
+            public function getConnection(?string $name = null){}
+            public function getConnections(){ return []; }
+            public function getConnectionNames(){ return []; }
+        };
+
+        $helper = new LongRunningHelper($registry);
+
+        $provider = new JsonProvider($locator, $helper);
+        $definition = $this->createMock(ExportDefinitionInterface::class);
+        $provider->addExportData(['foo' => 'bar'], [], $definition, []);
+        $provider->exportData([], $definition, ['storage' => 's3', 'file' => 'out.json']);
+
+        $this->assertTrue($fs->fileExists('out.json'));
+        $this->assertSame('[{"foo":"bar"}]', $fs->read('out.json'));
+    }
+}


### PR DESCRIPTION
## Summary
- support writing export output directly to storages via `putFile`
- use the new helper in CSV, JSON, Excel and XML providers
- document how to export to storages from the command line
- add unit test verifying export to a Flysystem storage

## Testing
- `phpunit --configuration phpunit.xml.dist`
- `vendor/bin/behat --format progress --no-interaction` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685db45fc2d88328afaed214154d8c72